### PR TITLE
Add autoload to the minor mode

### DIFF
--- a/org-bars.el
+++ b/org-bars.el
@@ -581,6 +581,7 @@ This is meant to be used in `post-command-hook'."
 (defvar-local org-bars-org-indent-mode nil
   "Hold the value of `org-indent-mode' before turning `org-bars-mode' on.")
 
+;;;###autoload
 (define-minor-mode org-bars-mode
   "Toggle `org-bars-mode' mode on or off."
   :global nil


### PR DESCRIPTION
This PR adds the `;;;###autoload` primitive to the minor mode function so that we don't need to `(require 'org-tabs)` before manually calling `org-bars-mode`.